### PR TITLE
feat: add pi agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository powers **agent-align**, a Go utility for synchronizing MCP (model
 configuration profile) configs across coding agents such as Copilot, Codex, Claude
-Code, Gemini, Kilocode, OpenCode, VS Code, and others. It keeps every agent's
+Code, Gemini, Kilocode, OpenCode, Pi, VS Code, and others. It keeps every agent's
 configuration
 in lockstep so you can iterate on a single MCP template and automatically
 propagate changes to the rest of the toolchain.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -208,6 +208,7 @@ codex | `~/.codex/config.toml` | TOML | `mcp_servers`
 claudecode | `~/.claude.json` | JSON | `mcpServers`
 gemini | `~/.gemini/settings.json` | JSON | `mcpServers`
 kilocode | Platform-dependent (see note below) | JSON | `mcpServers`
+pi | `~/.pi/agent/mcp.json` | JSON | `mcpServers`
 
 Every agent accepts a `path` override in `targets.agents` if your installation
 lives elsewhere.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 agent-align is a Go-based utility that keeps MCP configuration files aligned
 across coding agents such as Copilot, VSCode, Codex, Claude Code, Gemini,
-Kilocode, OpenCode, and others. Define your MCP servers once in
+Kilocode, OpenCode, Pi, and others. Define your MCP servers once in
 `agent-align-mcp.yml` and agent-align
 converts that configuration into the formats required by each tool while
 applying agent-specific tweaks automatically. Detailed documentation is hosted
@@ -215,6 +215,7 @@ codex | `~/.codex/config.toml` | TOML | `mcp_servers`
 claudecode | `~/.claude.json` | JSON | `mcpServers`
 gemini | `~/.gemini/settings.json` | JSON | `mcpServers`
 kilocode | Platform-dependent (see note below) | JSON | `mcpServers`
+pi | `~/.pi/agent/mcp.json` | JSON | `mcpServers`
 
 ## Testing
 

--- a/cmd/agent-align/config.embedded.yml
+++ b/cmd/agent-align/config.embedded.yml
@@ -15,6 +15,7 @@ mcpServers:
       - name: gemini
         path: ~/.qwen/settings.json # qwen uses the same format as gemini, so re-use that target here
       - name: kilocode
+      - name: pi
     additionalTargets:
       json:
         - filePath: /path/to/additional_targets.json

--- a/config.example.yml
+++ b/config.example.yml
@@ -17,6 +17,7 @@ mcpServers:
       - name: gemini
         path: ~/.qwen/settings.json # qwen uses the same format as gemini, so re-use that target here
       - name: kilocode
+      - name: pi
     additionalTargets:
       json:
         - filePath: /path/to/additional_targets.json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ codex | `~/.codex/config.toml` | TOML | `mcp_servers`
 claudecode | `~/.claude.json` | JSON | `mcpServers`
 gemini | `~/.gemini/settings.json` | JSON | `mcpServers`
 kilocode | Platform-dependent (see note below) | JSON | `mcpServers`
+pi | `~/.pi/agent/mcp.json` | JSON | `mcpServers`
 
 Every agent accepts a `path` override in `targets.agents` if your installation
 lives elsewhere.

--- a/docs/formatter-design.md
+++ b/docs/formatter-design.md
@@ -23,6 +23,7 @@ Codex | TOML | `mcp_servers` | `~/.codex/config.toml`
 ClaudeCode | JSON | `mcpServers` | `~/.claude.json`
 Gemini | JSON | `mcpServers` | `~/.gemini/settings.json`
 Kilocode | JSON | `mcpServers` | Platform-dependent (see note below)
+Pi | JSON | `mcpServers` | `~/.pi/agent/mcp.json`
 
 ## Core Types
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 Agent Align is a Go-based utility that keeps MCP configuration files aligned
 across coding agents such as Copilot, Codex, Claude Code, Gemini, Kilocode,
-OpenCode, and others. Define your MCP servers once in a neutral YAML file and
+OpenCode, Pi, and others. Define your MCP servers once in a neutral YAML file and
 Agent Align will
 convert it into the formats required by each tool while applying
 destination-specific tweaks automatically.

--- a/internal/docs/formatter-design.md
+++ b/internal/docs/formatter-design.md
@@ -23,6 +23,7 @@ Codex | TOML | `mcp_servers` | `~/.codex/config.toml`
 ClaudeCode | JSON | `mcpServers` | `~/.claude.json`
 Gemini | JSON | `mcpServers` | `~/.gemini/settings.json`
 Kilocode | JSON | `mcpServers` | Platform-dependent (see note below)
+Pi | JSON | `mcpServers` | `~/.pi/agent/mcp.json`
 
 ## Core Types
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -36,7 +36,7 @@ type AgentResult struct {
 	Content string
 }
 
-var supportedAgentList = []string{"copilot", "vscode", "codex", "claudecode", "gemini", "kilocode", "opencode"}
+var supportedAgentList = []string{"copilot", "vscode", "codex", "claudecode", "gemini", "kilocode", "opencode", "pi"}
 
 // SupportedAgents returns a list of supported agent names.
 func SupportedAgents() []string {
@@ -106,6 +106,13 @@ func GetAgentConfig(agent, overridePath string) (AgentConfig, error) {
 			FilePath: applyOverride(overridePath, filepath.Join(homeDir, ".config", "opencode", "opencode.jsonc")),
 			NodeName: "mcp",
 			Format:   "jsonc",
+		}, nil
+	case "pi":
+		return AgentConfig{
+			Name:     name,
+			FilePath: applyOverride(overridePath, filepath.Join(homeDir, ".pi", "agent", "mcp.json")),
+			NodeName: "mcpServers",
+			Format:   "json",
 		}, nil
 	default:
 		return AgentConfig{}, fmt.Errorf("unsupported agent: %s", agent)

--- a/internal/syncer/syncer_test.go
+++ b/internal/syncer/syncer_test.go
@@ -80,7 +80,7 @@ func TestSyncerSync(t *testing.T) {
 
 func TestSupportedAgents(t *testing.T) {
 	agents := SupportedAgents()
-	expected := []string{"copilot", "vscode", "codex", "claudecode", "gemini", "kilocode", "opencode"}
+	expected := []string{"copilot", "vscode", "codex", "claudecode", "gemini", "kilocode", "opencode", "pi"}
 	if len(agents) != len(expected) {
 		t.Fatalf("expected %d agents, got %d", len(expected), len(agents))
 	}
@@ -210,6 +210,52 @@ func TestFormatClaudeConfigPreservesExistingSettings(t *testing.T) {
 		t.Fatalf("result not valid JSON: %v", err)
 	}
 	if parsed["theme"] != "light" {
+		t.Fatalf("theme should be preserved, got %v", parsed["theme"])
+	}
+	if parsed["other"] != true {
+		t.Fatalf("other should be preserved, got %v", parsed["other"])
+	}
+	mcpServers, ok := parsed["mcpServers"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("mcpServers missing in output: %v", parsed)
+	}
+	if _, ok := mcpServers["new"]; !ok {
+		t.Fatal("new server should be present in mcpServers block")
+	}
+	if _, ok := mcpServers["old"]; ok {
+		t.Fatal("old server should have been replaced")
+	}
+}
+
+func TestFormatPiConfigPreservesExistingSettings(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+	existing := `{
+  "theme": "dark",
+  "mcpServers": {
+    "old": {
+      "command": "node"
+    }
+  },
+  "other": true
+}`
+	if err := os.WriteFile(path, []byte(existing), 0o644); err != nil {
+		t.Fatalf("failed to write existing config: %v", err)
+	}
+
+	servers := map[string]interface{}{
+		"new": map[string]interface{}{
+			"command": "npx",
+		},
+	}
+	cfg := AgentConfig{Name: "pi", FilePath: path, NodeName: "mcpServers", Format: "json"}
+	result := formatConfig(cfg, servers)
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result not valid JSON: %v", err)
+	}
+	if parsed["theme"] != "dark" {
 		t.Fatalf("theme should be preserved, got %v", parsed["theme"])
 	}
 	if parsed["other"] != true {


### PR DESCRIPTION
## Summary

Adds support for the **Pi** coding agent (by Earendil Inc.) for MCP config synchronization.

## Pi agent config details

Researched from the official pi.dev package docs and the [pi-mcp-adapter](https://github.com/nicobailon/pi-mcp-adapter) source:

- **Config path**: `~/.pi/agent/mcp.json` (Pi's global MCP override; overridable via `$PI_CODING_AGENT_DIR`)
- **Format**: JSON
- **Root node**: `mcpServers`
- **Server entry structure**: standard `command`/`args`/`env` — identical to Claude Code, Copilot, Gemini, and Kilocode

Because Pi uses the standard `command`/`args`/`env` schema, no custom transformer is needed (the existing `NoOpTransformer` applies, same as `vscode`/`kilocode`). The `$PI_CODING_AGENT_DIR` env override is covered by agent-align's existing `path:` override mechanism.

## Changes

### Code
- `internal/syncer/syncer.go` — added `"pi"` to `supportedAgentList` and a `case "pi":` returning `AgentConfig{FilePath: ~/.pi/agent/mcp.json, NodeName: "mcpServers", Format: "json"}`
- `internal/syncer/syncer_test.go` — added `"pi"` to `TestSupportedAgents` and a `TestFormatPiConfigPreservesExistingSettings` test

### Docs / examples
- Updated supported-agents tables in `README.md`, `CONFIGURATION.md`, `docs/configuration.md`, `docs/formatter-design.md`, and `internal/docs/formatter-design.md`
- Added Pi to intro sentences in `README.md` and `docs/index.md`
- Added `- name: pi` to `config.example.yml` and `cmd/agent-align/config.embedded.yml`
- Added "Pi" to `AGENTS.md` prose

## Test plan

- [x] `go test -coverprofile=coverage.out ./...` — all packages pass
- [x] `npx markdownlint-cli2 --fix '**/*.md'` — no new issues (4 pre-existing errors unrelated to this change)